### PR TITLE
Fix DHO4000 memory readout

### DIFF
--- a/src/scpi/scpi_usbtmc_libusb.c
+++ b/src/scpi/scpi_usbtmc_libusb.c
@@ -629,7 +629,7 @@ static int scpi_usbtmc_libusb_read_data(void *priv, char *buf, int maxlen)
 	if (uscpi->response_bytes_read >= uscpi->response_length) {
 		if (uscpi->remaining_length > 0) {
 			if (scpi_usbtmc_bulkin_continue(uscpi, uscpi->buffer,
-			                                sizeof(uscpi->buffer)) <= 0)
+			                                sizeof(uscpi->buffer)) < 0)
 				return SR_ERR;
 		} else {
 			if (uscpi->bulkin_attributes & EOM)


### PR DESCRIPTION
The DHO4000 series uses 0-length bulk packets as response to some WAV requests presumably to extend the processing time it has (these are valid packets, see https://stackoverflow.com/a/30960597). I've also validated that this does fix loading large memory views.